### PR TITLE
fix: fix max stack exceeding err cause by [].concat

### DIFF
--- a/src/client/Context.ts
+++ b/src/client/Context.ts
@@ -205,7 +205,7 @@ export class RDD<T> {
       func = serialize(func, env);
     }
     return this.mapPartitions(
-      (partition: T[]) => ([] as T1[]).concat(...partition.map(func)),
+      (partition: T[]) => partition.map(func).reduce((pre,c) => pre.concat(c),[] as T1[]),
       {
         func,
       },


### PR DESCRIPTION
concat may cause 'Maximum call stack size exceeded' error with mass amount of params.
eg:
`[].concat(...new Array(1000000).fill(0))`